### PR TITLE
Add support for ox_lib radial menu

### DIFF
--- a/shared/config.lua
+++ b/shared/config.lua
@@ -27,6 +27,7 @@ Config.NotifyOptions = {
 Config.OutfitCodeLength = 10
 
 Config.UseRadialMenu = false
+Config.UseOxRadial = false -- Set to true to use ox_lib radial menu, both this and UseRadialMenu must be true 
 
 Config.EnablePedsForShops = true
 Config.EnablePedsForClothingRooms = true


### PR DESCRIPTION
Keeps the current qb-radialmenu support while adding a config option to use the new ox_lib radial menu instead. Now adds the radial option when entering the zone instead of on menu open as ox_lib does not have an equivalent event trigger