### PR TITLE
Fix loadout bug

### DIFF
--- a/client/framework/esx/compatibility.lua
+++ b/client/framework/esx/compatibility.lua
@@ -35,6 +35,7 @@ RegisterNetEvent("skinchanger:loadSkin", function(skin, cb)
     else -- add validation invisible when failed registration (maybe server restarted when apply skin)
         SetInitialClothes(Config.InitialPlayerClothes[Framework.GetGender(true)])
     end
+	TriggerEvent('esx:restoreLoadout')
     Framework.CachePed()
 	if cb ~= nil then
 		cb()


### PR DESCRIPTION
This fixes a problem with the loadout, specifically the following problem (I had that problem with the default esx inventory. I don't know if it happened with other inventories.): 
When you get a weapon, exit the server and reconnect, the weapon does not appear but it is in the sql.

Closes #269 