### PR TITLE
refactor: ace permissions

### DIFF
--- a/server/permissions.lua
+++ b/server/permissions.lua
@@ -1,23 +1,10 @@
-local configAces = {}
-
-for i = 1, #Config.Peds.pedConfig do
-    local pedConfigEntry = Config.Peds.pedConfig[i]
-    if pedConfigEntry.aces then
-        for k = 1, #pedConfigEntry.aces do
-            configAces[pedConfigEntry.aces[k]] = true
-        end
-    end
-end
-
 lib.callback.register("illenium-appearance:server:GetPlayerAces", function()
     local src = source
     local allowedAces = {}
-
-    for k in pairs(configAces) do
-        if IsPlayerAceAllowed(src, k) then
+    for i = 1, #Config.Aces do
+        if IsPlayerAceAllowed(src, Config.Aces[i]) then
             allowedAces[#allowedAces+1] = k
         end
     end
-
     return allowedAces
 end)

--- a/server/permissions.lua
+++ b/server/permissions.lua
@@ -1,44 +1,23 @@
-local resetTimer = GetGameTimer()
-local allAces = {}
+local configAces = {}
+
+for i = 1, #Config.Peds.pedConfig do
+    local pedConfigEntry = Config.Peds.pedConfig[i]
+    if pedConfigEntry.aces then
+        for k = 1, #pedConfigEntry.aces do
+            configAces[pedConfigEntry.aces[k]] = true
+        end
+    end
+end
 
 lib.callback.register("illenium-appearance:server:GetPlayerAces", function()
     local src = source
     local allowedAces = {}
-    for k in pairs(allAces) do
+
+    for k in pairs(configAces) do
         if IsPlayerAceAllowed(src, k) then
-            allowedAces[#allowedAces + 1] = k
+            allowedAces[#allowedAces+1] = k
         end
     end
+
     return allowedAces
 end)
-
-local function findAceFromSecurityMessage(message)
-    local words = {}
-    for word in message:gmatch("%S+") do words[#words + 1] = word end
-    return words[3]
-end
-
-RegisterConsoleListener(function(channel, message)
-    if channel ~= "security" then
-        return
-    end
-
-    local ace = findAceFromSecurityMessage(message)
-    if ace and ((GetGameTimer() - resetTimer) > Config.ACEResetCooldown) then
-        allAces = {}
-    end
-
-    if ace then
-        allAces[ace] = true
-        resetTimer = GetGameTimer()
-    end
-end)
-
-if Config.EnableACEPermissions then
-    CreateThread(function()
-        while true do
-            ExecuteCommand("list_aces")
-            Wait(Config.ACEListCooldown)
-        end
-    end)
-end

--- a/server/permissions.lua
+++ b/server/permissions.lua
@@ -2,8 +2,9 @@ lib.callback.register("illenium-appearance:server:GetPlayerAces", function()
     local src = source
     local allowedAces = {}
     for i = 1, #Config.Aces do
-        if IsPlayerAceAllowed(src, Config.Aces[i]) then
-            allowedAces[#allowedAces+1] = k
+        local ace = Config.Aces[i]
+        if IsPlayerAceAllowed(src, ace) then
+            allowedAces[#allowedAces+1] = ace
         end
     end
     return allowedAces

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -94,6 +94,9 @@ Config.DisableProps = {
     Bracelets = false
 }
 
+---@type string[]
+Config.Aces = {} -- list of ace permissions used for blacklisting
+
 Config.Blips = {
     ["clothing"] = {
         Show = true,

--- a/shared/config.lua
+++ b/shared/config.lua
@@ -73,11 +73,6 @@ Config.ReloadSkinCooldown = 5000
 
 Config.AutomaticFade = false -- Enables automatic fading and hides the Fade section from Hair
 
--- ACE Permissions Config
-Config.EnableACEPermissions = false
-Config.ACEResetCooldown = 5000
-Config.ACEListCooldown = 60 * 60 * 1000 -- 1 Hour
-
 Config.DisableComponents = {
     Masks = false,
     UpperBody = false,


### PR DESCRIPTION
Rather than use console prints of all possible ace permissions, introducing a config option for the user to specify all the ace permissions to check against. This supports dynamic permission assignment using ox_lib ACL, as the ace permission may not be assigned to any players on server start.

An even better follow-up step from this PR might be to pull the list of ace permissions to check against from the various blacklist configs rather than duplicate the list in a different part of config. But this is a simpler stop-gap solution than current main