### PR TITLE
Delay player customisation if client is in a "transitional" state

### DIFF
--- a/game/customization.lua
+++ b/game/customization.lua
@@ -535,6 +535,8 @@ function client.getHeading() return playerHeading end
 
 local callback
 function client.startPlayerCustomization(cb, conf)
+    repeat Wait(0) until IsScreenFadedIn() and not IsPlayerTeleportActive() and GetPlayerSwitchState() == 12
+
     playerAppearance = client.getPedAppearance(cache.ped)
     playerCoords = GetEntityCoords(cache.ped, true)
     playerHeading = GetEntityHeading(cache.ped)


### PR DESCRIPTION
Prevents setting up the camera and enabling the UI while a player is still loading, i.e.
- screen is faded out
- player is teleporting
- player is switching

Generally eases the transition from character creation into customisation.