### PR TITLE
chore/fix(fxmanifest): bump version to latest fixing version check

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -4,7 +4,7 @@ game "gta5"
 author "snakewiz & iLLeniumStudios"
 description "A flexible player customization script for FiveM servers."
 repository "https://github.com/iLLeniumStudios/illenium-appearance"
-version "main"
+version "5.6.1"
 
 lua54 "yes"
 


### PR DESCRIPTION
fixes ox_lib's version check, currently as is will throw the following error upon running the resource:

![image](https://github.com/iLLeniumStudios/illenium-appearance/assets/170161138/7c12dd44-066c-4456-a55e-a6cdfcf7eca4)
