### PR TITLE
Favorite Outfits System

### DIFF
--- a/locales/en.lua
+++ b/locales/en.lua
@@ -257,6 +257,15 @@ Locales["en"] = {
         },
         manage = {
             title = "👔 | Manage %s Outfits"
+        },
+        favorite = {
+            title = "Favorites",
+            description = "Click here to add your outfits to the top of the list",
+            input = "Favorite Outfits",
+            success = {
+                title = "Success",
+                description = "Outfits added to favorites"
+            }
         }
     },
     jobOutfits = {

--- a/locales/es-ES.lua
+++ b/locales/es-ES.lua
@@ -257,6 +257,15 @@ Locales["es-ES"] = {
         },
         manage = {
             title = "👔 | Administrar trajes %s"
+        },
+        favorite = {
+            title = "Favoritos",
+            description = "Haz click aqúi para añadir tus atuendos al inicio de la lista",
+            input = "Atuendos favoritos",
+            success = {
+                title = "Éxito",
+                description = "Los atuendos han sido añadidos a favoritos"
+            }
         }
     },
     jobOutfits = {

--- a/server/database/playeroutfits.lua
+++ b/server/database/playeroutfits.lua
@@ -31,6 +31,10 @@ function Database.PlayerOutfits.Update(outfitID, model, components, props)
     })
 end
 
+function Database.PlayerOutfits.Favorite(outfitName)
+    return MySQL.update.await("UPDATE player_outfits SET favorite = (favorite ^ 1) WHERE outfitname = ?", {outfitName})
+end
+
 function Database.PlayerOutfits.DeleteByID(id)
     MySQL.query.await("DELETE FROM player_outfits WHERE id = ?", {id})
 end

--- a/server/server.lua
+++ b/server/server.lua
@@ -25,7 +25,8 @@ local function getOutfitsForPlayer(citizenid)
             name = result[i].outfitname,
             model = result[i].model,
             components = json.decode(result[i].components),
-            props = json.decode(result[i].props)
+            props = json.decode(result[i].props),
+            favorite = result[i].favorite
         }
     end
 end
@@ -243,6 +244,35 @@ RegisterNetEvent("illenium-appearance:server:updateOutfit", function(id, model, 
             position = Config.NotifyOptions.position
         })
     end
+end)
+
+RegisterNetEvent("illenium-appearance:server:favoriteOutfits", function(outfits)
+    local src = source
+    local citizenID = Framework.GetPlayerID(src)
+    if outfitCache[citizenID] == nil then
+        getOutfitsForPlayer(citizenID)
+    end
+
+    for i = 1, #outfitCache[citizenID], 1 do
+        local outfit = outfitCache[citizenID][i]
+        if outfit.favorite then
+            outfit.favorite = false
+            Database.PlayerOutfits.Favorite(outfit.name)
+        end
+        for _, v in pairs(outfits) do
+            if outfit.name == v then
+                outfit.favorite = true
+                Database.PlayerOutfits.Favorite(outfit.name)
+            end
+        end
+    end
+    
+    lib.notify(src, {
+        title = _L("outfits.favorite.success.title"),
+        description = _L("outfits.favorite.success.description"),
+        type = "success",
+        position = Config.NotifyOptions.position
+    })
 end)
 
 RegisterNetEvent("illenium-appearance:server:saveManagementOutfit", function(outfitData)

--- a/sql/player_outfits.sql
+++ b/sql/player_outfits.sql
@@ -12,6 +12,7 @@ CREATE TABLE IF NOT EXISTS `player_outfits` (
   `model` varchar(50) DEFAULT NULL,
   `props` varchar(1000) DEFAULT NULL,
   `components` varchar(1500) DEFAULT NULL,
+  `favorite` tinyint(1) NOT NULL DEFAULT '0',
   PRIMARY KEY (`id`),
   UNIQUE KEY `citizenid_outfitname_model` (`citizenid`,`outfitname`,`model`),
   KEY `citizenid` (`citizenid`)


### PR DESCRIPTION
I thought about adding a favorite outfits system for the change outfits menu. Initially Initially I thought to create a separate menu like the change or update outfits menu, but it was too much clutter. So I decided to make a button that pins the outfits to the top of the list, also working as a separator. 
I would have loved to add a star to the left side of the outfit buttons to mark them as favorites, but the ox_lib didn't have any parameters for that and I didn't want to modify the system to that extent.
It's a bit hacky  but I think it's the easiest for the user experience, as a separate menu would defeat its purpose of being accessible  as it requires more clicks if you want to see your favorite and non-favorite outfits.
Another option I've thought of if you prefer the separate menu option is to give star icons to the favorite outfits in the all outfits menu. The problem is that to remove them from favorites you'll have to go to another menu, making it confusing. However, that's easy to change because it only affects the UI.

Feel free to take whatever part is usefull (mostly the backend) and modify it!

Video:
https://github.com/user-attachments/assets/260d1953-65d4-4ffc-b9ff-9ab87c6b44d2

