### PR TITLE
fix(game/customization): prevent hanging if player switch is never used

### DIFF
--- a/game/customization.lua
+++ b/game/customization.lua
@@ -535,7 +535,7 @@ function client.getHeading() return playerHeading end
 
 local callback
 function client.startPlayerCustomization(cb, conf)
-    repeat Wait(0) until IsScreenFadedIn() and not IsPlayerTeleportActive() and GetPlayerSwitchState() == 12
+    repeat Wait(0) until IsScreenFadedIn() and not IsPlayerTeleportActive() and (GetPlayerSwitchState() == 0 or GetPlayerSwitchState() == 12)
 
     playerAppearance = client.getPedAppearance(cache.ped)
     playerCoords = GetEntityCoords(cache.ped, true)


### PR DESCRIPTION
The customisation can be stuck in an infinite loop if the server the script is running on doesn't make use of the player switch natives.

Also checked against ox_core, and the earliest state picked up is 3 during the switch. so this will not break ox_core.