### PR TITLE
Providing esx_skin & skinchanger by default

### DIFF
--- a/fxmanifest.lua
+++ b/fxmanifest.lua
@@ -94,3 +94,5 @@ files {
 }
 
 ui_page "web/dist/index.html"
+
+provides { "esx_skin", "skinchanger" }


### PR DESCRIPTION
Updated fxmanifest.lua to ensure esx_skin and skinchanger are provided by default 