### PR TITLE
Pass onSubmit callback to CreateFirstCharacter event

### DIFF
--- a/client/framework/qb/main.lua
+++ b/client/framework/qb/main.lua
@@ -86,11 +86,11 @@ RegisterNetEvent("QBCore:Client:OnPlayerLoaded", function()
     InitAppearance()
 end)
 
-RegisterNetEvent("qb-clothes:client:CreateFirstCharacter", function()
+RegisterNetEvent("qb-clothes:client:CreateFirstCharacter", function(onSubmit)
     QBCore.Functions.GetPlayerData(function(pd)
         PlayerData = pd
         setClientParams()
-        InitializeCharacter(Framework.GetGender(true))
+        InitializeCharacter(Framework.GetGender(true), onSubmit)
     end)
 end)
 


### PR DESCRIPTION
# Overview

This PR adds `onSubmit` as an arg to the `qb-clothes:client:CreateFirstCharacter` and passes it to `InitializeCharacter`. 

# Details

While default qb scripts dont pass any args, some custom scripts utilize this same event and pass through an onSubmit callback function to trigger once the character is created.

In InitializeCharacter it first checks that the `onSubmit` function is defined before trying to be used. Therefore this change is still safe for scripts that won't be passing any value in for `onSubmit`.
![image](https://github.com/user-attachments/assets/75697af7-296c-4a7f-a331-4e71808199bf)
