### PR TITLE
fix: resolve typos, nil pointer exceptions, and outfit permission checks

### DIFF
--- a/client/client.lua
+++ b/client/client.lua
@@ -34,12 +34,15 @@ local function LoadPlayerUniform(reset)
 
             TriggerEvent("illenium-appearance:client:changeOutfit", uniform)
         else
-            local outfits = Config.Outfits[uniformData.jobName][uniformData.gender]
+            local jobOutfits = Config.Outfits[uniformData.jobName]
+            local outfits = jobOutfits and jobOutfits[uniformData.gender]
             local uniform = nil
-            for i = 1, #outfits, 1 do
-                if outfits[i].name == uniformData.label then
-                    uniform = outfits[i]
-                    break
+            if outfits then
+                for i = 1, #outfits, 1 do
+                    if outfits[i].name == uniformData.label then
+                        uniform = outfits[i]
+                        break
+                    end
                 end
             end
 
@@ -727,7 +730,7 @@ RegisterNetEvent("illenium-appearance:client:reloadSkin", function(bypassChecks)
         end
         client.setPlayerAppearance(appearance)
         if Config.PersistUniforms then
-            LoadPlayerUniform(bypassChecks)
+            LoadPlayerUniform()
         end
         RestorePlayerStats()
     end)

--- a/client/common.lua
+++ b/client/common.lua
@@ -3,6 +3,9 @@ function CheckDuty()
 end
 
 function IsPlayerAllowedForOutfitRoom(outfitRoom)
+    if not outfitRoom or not outfitRoom.citizenIDs or #outfitRoom.citizenIDs == 0 then
+        return true
+    end
     local isAllowed = false
     local count = #outfitRoom.citizenIDs
     for i = 1, count, 1 do
@@ -11,7 +14,7 @@ function IsPlayerAllowedForOutfitRoom(outfitRoom)
             break
         end
     end
-    return isAllowed or not outfitRoom.citizenIDs or count == 0
+    return isAllowed
 end
 
 function GetPlayerJobOutfits(job)

--- a/client/outfits.lua
+++ b/client/outfits.lua
@@ -136,7 +136,7 @@ RegisterNetEvent("illenium-appearance:client:openOutfitMenu", function()
     OpenMenu(nil, "outfit")
 end)
 
-RegisterNetEvent("illenium-apearance:client:outfitsCommand", function(isJob)
+RegisterNetEvent("illenium-appearance:client:outfitsCommand", function(isJob)
     local outfits = GetPlayerJobOutfits(isJob)
     TriggerEvent("illenium-appearance:client:openJobOutfitsMenu", outfits)
 end)

--- a/client/zones.lua
+++ b/client/zones.lua
@@ -186,12 +186,16 @@ AddEventHandler("onResourceStop", function(resource)
 end)
 
 RegisterNetEvent("illenium-appearance:client:OpenClothingRoom", function()
+    if not currentZone or not currentZone.index then return end
     local clothingRoom = Config.ClothingRooms[currentZone.index]
+    if not clothingRoom then return end
     local outfits = GetPlayerJobOutfits(clothingRoom.job)
     TriggerEvent("illenium-appearance:client:openJobOutfitsMenu", outfits)
 end)
 
 RegisterNetEvent("illenium-appearance:client:OpenPlayerOutfitRoom", function()
+    if not currentZone or not currentZone.index then return end
     local outfitRoom = Config.PlayerOutfitRooms[currentZone.index]
+    if not outfitRoom then return end
     OpenOutfitRoom(outfitRoom)
 end)

--- a/server/server.lua
+++ b/server/server.lua
@@ -57,6 +57,8 @@ end)
 
 lib.callback.register("illenium-appearance:server:importOutfitCode", function(source, outfitName, outfitCode)
     local citizenID = Framework.GetPlayerID(source)
+    if not citizenID then return nil end
+
     local existingOutfitCode = Database.PlayerOutfitCodes.GetByCode(outfitCode)
     if not existingOutfitCode then
         return nil
@@ -75,6 +77,10 @@ lib.callback.register("illenium-appearance:server:importOutfitCode", function(so
     if not id then
         print("Something went wrong while importing the outfit")
         return
+    end
+
+    if outfitCache[citizenID] == nil then
+        getOutfitsForPlayer(citizenID)
     end
 
     outfitCache[citizenID][#outfitCache[citizenID] + 1] = {
@@ -272,8 +278,13 @@ end)
 RegisterNetEvent("illenium-appearance:server:deleteOutfit", function(id)
     local src = source
     local citizenID = Framework.GetPlayerID(src)
+    if not citizenID then return end
     Database.PlayerOutfitCodes.DeleteByOutfitID(id)
     Database.PlayerOutfits.DeleteByID(id)
+
+    if outfitCache[citizenID] == nil then
+        getOutfitsForPlayer(citizenID)
+    end
 
     for k, v in ipairs(outfitCache[citizenID]) do
         if v.id == id then
@@ -335,11 +346,11 @@ end
 
 if Config.EnableJobOutfitsCommand then
     lib.addCommand("joboutfits", { help = _L("commands.joboutfits.title"), }, function(source)
-        TriggerClientEvent("illenium-apearance:client:outfitsCommand", source, true)
+        TriggerClientEvent("illenium-appearance:client:outfitsCommand", source, true)
     end)
 
     lib.addCommand("gangoutfits", { help = _L("commands.gangoutfits.title"), }, function(source)
-        TriggerClientEvent("illenium-apearance:client:outfitsCommand", source)
+        TriggerClientEvent("illenium-appearance:client:outfitsCommand", source)
     end)
 end
 


### PR DESCRIPTION
- Fix event name typo (illenium-apearance to illenium-appearance) in job/gang outfits commands.
- Prevent nil check crashes in LoadPlayerUniform, OpenClothingRoom, OpenPlayerOutfitRoom, and importOutfitCode / deleteOutfit.
- Correct permission evaluation logic in IsPlayerAllowedForOutfitRoom when no citizen IDs are configured.